### PR TITLE
Fix isNewMethod to deal with partially created methods

### DIFF
--- a/src/GToolkit-Pharo-Coder/GtPharoMethodCoder.class.st
+++ b/src/GToolkit-Pharo-Coder/GtPharoMethodCoder.class.st
@@ -703,7 +703,7 @@ GtPharoMethodCoder >> isMondrianPaintMethod: aMethodNode [
 
 { #category : #testing }
 GtPharoMethodCoder >> isNewMethod [
-	^ self currentSourceString isEmpty
+	^ (self currentSourceString isEmpty) or: [selector isNil]
 ]
 
 { #category : #testing }


### PR DESCRIPTION
If selector is still nil, the method has not been successfully compiled yet