### PR TITLE
fix: disable 'class' or 'instance' option

### DIFF
--- a/src/GToolkit-Pharo-Coder-UI/GtBehaviorMethodCoderTagsElement.class.st
+++ b/src/GToolkit-Pharo-Coder-UI/GtBehaviorMethodCoderTagsElement.class.st
@@ -62,6 +62,7 @@ GtBehaviorMethodCoderTagsElement >> newClassTag [
 								beSmallSize;
 								aptitude: BrGlamorousButtonRectangularAptitude + BrGlamorousButtonLabelAptitude;
 								label: self behaviorOtherSideName;
+								disabled: self methodCoderUIModel coder canMoveMethodToInstanceOrClass not;
 								action: [ :aButton | 
 									aButton fireEvent: BrDropdownHideWish new.
 									self methodCoderUIModel coder moveMethodToInstanceOrClass.


### PR DESCRIPTION
Disable 'class' or 'instance' option when method coder cannot be compiled. `canMoveMethodToInstanceOrClass` is already called before firing `moveMethodToInstanceOrClass` so the button will do nothing. https://github.com/feenkcom/gtoolkit/issues/1981