### PR TITLE
Fix text selection tracking after source code formatting

### DIFF
--- a/src/GToolkit-Pharo-Coder-Examples/GtPharoMethodCoderByScripterExamples.class.st
+++ b/src/GToolkit-Pharo-Coder-Examples/GtPharoMethodCoderByScripterExamples.class.st
@@ -6767,196 +6767,6 @@ GtPharoMethodCoderByScripterExamples >> forKeywordRename_06_click_cancel [
 	^ scripter
 ]
 
-{ #category : #'examples - format selection' }
-GtPharoMethodCoderByScripterExamples >> formatMethodCoder_01_setup [
-	<gtExample>
-	| scripter |
-	scripter := self
-			scripterForBlock: [ GtPharoMethodCoder
-					forClass: Object
-					source: 'exampleMethod
-	| x |
-	x:=1+2.
-	^x' ].
-	scripter
-		checkStep: [ :s |
-			s
-				label: 'Check initial source';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each text asString ]
-					equals: [ 'exampleMethod
-	| x |
-	x:=1+2.
-	^x' ] ].
-	^ scripter
-]
-
-{ #category : #'examples - format selection' }
-GtPharoMethodCoderByScripterExamples >> formatMethodCoder_02_select [
-	<gtExample>
-	| scripter |
-	scripter := self formatMethodCoder_01_setup.
-	scripter
-		doStep: [ :s |
-			s
-				label: 'Select x:=1+2';
-				id: GtSourceCoderEditorId;
-				action: [ :aSourceEditor | aSourceEditor editor select: 22 to: 28 ] ].
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert selected text is x:=1+2';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor selectedText asString ] equals: 'x:=1+2' ].
-	^ scripter
-]
-
-{ #category : #'examples - format selection' }
-GtPharoMethodCoderByScripterExamples >> formatMethodCoder_03_format [
-	<gtExample>
-	| scripter |
-	scripter := self formatMethodCoder_02_select.
-	scripter shortcut
-		id: GtSourceCoderEditorId;
-		id: GtSourceCoderEditorInnerId;
-		combination: BlKeyCombination primaryShiftF;
-		play.
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert selection adapted to formatted text';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor selectedText asString ] equals: 'x := 1 + 2' ].
-	^ scripter
-]
-
-{ #category : #'examples - format selection' }
-GtPharoMethodCoderByScripterExamples >> formatMethodCoder_04_formatWithoutSelection [
-	<gtExample>
-	| scripter |
-	scripter := self formatMethodCoder_01_setup.
-	scripter shortcut
-		id: GtSourceCoderEditorId;
-		id: GtSourceCoderEditorInnerId;
-		combination: BlKeyCombination primaryShiftF;
-		play.
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert no selection after format without selection';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor hasSelection ] equals: false ].
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert source is formatted';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each text asString ]
-					equals: 'exampleMethod
-	| x |
-	x := 1 + 2.
-	^ x' ].
-	^ scripter
-]
-
-{ #category : #'examples - format selection' }
-GtPharoMethodCoderByScripterExamples >> formatMethodCoder_05_formatAlreadyFormatted [
-	<gtExample>
-	| scripter formattedSource |
-	formattedSource := (RBParser
-			parseMethod: 'exampleMethod
-	| x |
-	x:=1+2.
-	^x') formattedCode.
-	scripter := self
-			scripterForBlock: [ GtPharoMethodCoder forClass: Object source: formattedSource ].
-	scripter
-		doStep: [ :s |
-			s
-				label: 'Select x := 1 + 2';
-				id: GtSourceCoderEditorId;
-				action: [ :aSourceEditor | aSourceEditor editor select: 22 to: 32 ] ].
-	scripter shortcut
-		id: GtSourceCoderEditorId;
-		id: GtSourceCoderEditorInnerId;
-		combination: BlKeyCombination primaryShiftF;
-		play.
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert selection unchanged after formatting already-formatted code';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor selectedText asString ] equals: 'x := 1 + 2' ].
-	^ scripter
-]
-
-{ #category : #'examples - format selection' }
-GtPharoMethodCoderByScripterExamples >> formatMethodCoder_06_formatWithPartialSelection [
-	<gtExample>
-	| scripter |
-	scripter := self formatMethodCoder_01_setup.
-	scripter
-		doStep: [ :s |
-			s
-				label: 'Select +2';
-				id: GtSourceCoderEditorId;
-				action: [ :aSourceEditor | aSourceEditor editor select: 26 to: 28 ] ].
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert selected text before format';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor selectedText asString ] equals: '+2' ].
-	scripter shortcut
-		id: GtSourceCoderEditorId;
-		id: GtSourceCoderEditorInnerId;
-		combination: BlKeyCombination primaryShiftF;
-		play.
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert selection snaps to message node after format';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor selectedText asString ] equals: '+ 2' ].
-	^ scripter
-]
-
-{ #category : #'examples - format selection' }
-GtPharoMethodCoderByScripterExamples >> formatMethodCoder_07_formatWithMidTokenSelection [
-	<gtExample>
-	| scripter |
-	scripter := self
-			scripterForBlock: [ GtPharoMethodCoder
-					forClass: Object
-					source: 'exampleMethod
-    | test1 test2 test3 test4 test5a test6 |
-    test1 := 1. test2 := 2.  test3 := 3.   test4 := 4.    test5a := 5.    test6 := 6' ].
-	scripter
-		doStep: [ :s |
-			s
-				label: 'Select est5 (5th)';
-				id: GtSourceCoderEditorId;
-				action: [ :aSourceEditor | aSourceEditor editor select: 118 to: 122 ] ].
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert selected text before format';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor selectedText asString ] equals: 'est5' ].
-	scripter shortcut
-		id: GtSourceCoderEditorId;
-		id: GtSourceCoderEditorInnerId;
-		combination: BlKeyCombination primaryShiftF;
-		play.
-	scripter
-		assertStep: [ :s |
-			s
-				label: 'Assert selection snaps to same "est5" after format';
-				id: GtSourceCoderEditorId;
-				value: [ :each | each editor selectedText asString ] equals: 'est5' ].
-	^ scripter
-]
-
 { #category : #'examples - move variable scope' }
 GtPharoMethodCoderByScripterExamples >> forMoveVariableScope_01_setup [
 	<gtExample>
@@ -8995,6 +8805,282 @@ GtPharoMethodCoderByScripterExamples >> forUnaryRename_02_shortcut [
 				onBreadthFirstChildOfClass: GtRenameEditor ].
 
 	^ aScripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_01_setup [
+	<gtExample>
+	| scripter |
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder
+					forClass: Object
+					source: 'exampleMethod
+	| x |
+	x:=1+2.
+	^x' ].
+	scripter
+		checkStep: [ :s |
+			s
+				label: 'Check initial source';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each text asString ]
+					equals: [ 'exampleMethod
+	| x |
+	x:=1+2.
+	^x' ] ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_02_select [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_01_setup.
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select x:=1+2';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 22 to: 28 ] ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selected text is x:=1+2';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'x:=1+2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_03_format [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_02_select.
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection adapted to formatted text';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'x := 1 + 2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_04_formatWithoutSelection [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_01_setup.
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert no selection after format without selection';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor hasSelection ] equals: false ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert source is formatted';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each text asString ]
+					equals: 'exampleMethod
+	| x |
+	x := 1 + 2.
+	^ x' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_05_formatAlreadyFormatted [
+	<gtExample>
+	| scripter formattedSource |
+	formattedSource := (RBParser
+			parseMethod: 'exampleMethod
+	| x |
+	x:=1+2.
+	^x') formattedCode.
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder forClass: Object source: formattedSource ].
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select x := 1 + 2';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 22 to: 32 ] ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection unchanged after formatting already-formatted code';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'x := 1 + 2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_06_formatWithPartialSelection [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_01_setup.
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select +2';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 26 to: 28 ] ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selected text before format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '+2' ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection snaps to message node after format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '+ 2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_07_formatWithMidTokenSelection [
+	<gtExample>
+	| scripter |
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder
+					forClass: Object
+					source: 'exampleMethod
+    | test1 test2 test3 test4 test5a test6 |
+    test1 := 1. test2 := 2.  test3 := 3.   test4 := 4.    test5a := 5.    test6 := 6' ].
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select est5 (5th)';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 118 to: 122 ] ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selected text before format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'est5' ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection snaps to same "est5" after format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'est5' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_08_formatAddsTokens [
+	<gtExample>
+	| scripter |
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder
+					forClass: Object
+					source: 'exampleMethod
+			^ #||' ].
+	scripter
+		doStep: [ :s | 
+			s
+				label: 'Select 2nd |';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 21 to: 22 ] ].
+	scripter
+		assertStep: [ :s | 
+			s
+				label: 'Assert selected text before format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '|' ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s | 
+			s
+				label: 'Assert selection snaps around the now added '' between # and |';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '|' ].
+	scripter
+		assertStep: [ :s | 
+			s
+				label: 'Assert selection snaps around the |';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '|' ].
+	scripter
+		assertStep: [ :s | 
+			s
+				label: 'Assert selection is around the second |';
+				id: GtSourceCoderEditorId;
+				value: [ :each | 
+						| index |
+						index := each editor selection indices first.
+						(each editor text at: index - 1) asString ]
+					equals: '|' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_09_formatRemovesTokens [
+	<gtExample>
+	| scripter |
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder
+					forClass: Object
+					source: 'exampleMethod
+			^ (1 + 2) + 3' ].
+	scripter
+		doStep: [ :s | 
+			s
+				label: 'Select 2)';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 24 to: 26 ] ].
+	scripter
+		assertStep: [ :s | 
+			s
+				label: 'Assert selected text before format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '2)' ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s | 
+			s
+				label: 'Assert selection reduces only to the 2, since the ) disappeared';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '2' ].
+	^ scripter
 ]
 
 { #category : #'examples - rename method' }

--- a/src/GToolkit-Pharo-Coder-Examples/GtPharoMethodCoderByScripterExamples.class.st
+++ b/src/GToolkit-Pharo-Coder-Examples/GtPharoMethodCoderByScripterExamples.class.st
@@ -6767,6 +6767,196 @@ GtPharoMethodCoderByScripterExamples >> forKeywordRename_06_click_cancel [
 	^ scripter
 ]
 
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_01_setup [
+	<gtExample>
+	| scripter |
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder
+					forClass: Object
+					source: 'exampleMethod
+	| x |
+	x:=1+2.
+	^x' ].
+	scripter
+		checkStep: [ :s |
+			s
+				label: 'Check initial source';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each text asString ]
+					equals: [ 'exampleMethod
+	| x |
+	x:=1+2.
+	^x' ] ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_02_select [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_01_setup.
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select x:=1+2';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 22 to: 28 ] ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selected text is x:=1+2';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'x:=1+2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_03_format [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_02_select.
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection adapted to formatted text';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'x := 1 + 2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_04_formatWithoutSelection [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_01_setup.
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert no selection after format without selection';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor hasSelection ] equals: false ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert source is formatted';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each text asString ]
+					equals: 'exampleMethod
+	| x |
+	x := 1 + 2.
+	^ x' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_05_formatAlreadyFormatted [
+	<gtExample>
+	| scripter formattedSource |
+	formattedSource := (RBParser
+			parseMethod: 'exampleMethod
+	| x |
+	x:=1+2.
+	^x') formattedCode.
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder forClass: Object source: formattedSource ].
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select x := 1 + 2';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 22 to: 32 ] ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection unchanged after formatting already-formatted code';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'x := 1 + 2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_06_formatWithPartialSelection [
+	<gtExample>
+	| scripter |
+	scripter := self formatMethodCoder_01_setup.
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select +2';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 26 to: 28 ] ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selected text before format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '+2' ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection snaps to message node after format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: '+ 2' ].
+	^ scripter
+]
+
+{ #category : #'examples - format selection' }
+GtPharoMethodCoderByScripterExamples >> formatMethodCoder_07_formatWithMidTokenSelection [
+	<gtExample>
+	| scripter |
+	scripter := self
+			scripterForBlock: [ GtPharoMethodCoder
+					forClass: Object
+					source: 'exampleMethod
+    | test1 test2 test3 test4 test5a test6 |
+    test1 := 1. test2 := 2.  test3 := 3.   test4 := 4.    test5a := 5.    test6 := 6' ].
+	scripter
+		doStep: [ :s |
+			s
+				label: 'Select est5 (5th)';
+				id: GtSourceCoderEditorId;
+				action: [ :aSourceEditor | aSourceEditor editor select: 118 to: 122 ] ].
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selected text before format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'est5' ].
+	scripter shortcut
+		id: GtSourceCoderEditorId;
+		id: GtSourceCoderEditorInnerId;
+		combination: BlKeyCombination primaryShiftF;
+		play.
+	scripter
+		assertStep: [ :s |
+			s
+				label: 'Assert selection snaps to same "est5" after format';
+				id: GtSourceCoderEditorId;
+				value: [ :each | each editor selectedText asString ] equals: 'est5' ].
+	^ scripter
+]
+
 { #category : #'examples - move variable scope' }
 GtPharoMethodCoderByScripterExamples >> forMoveVariableScope_01_setup [
 	<gtExample>

--- a/src/GToolkit-Pharo-Coder-Method/GtPharoMethodCoder.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtPharoMethodCoder.class.st
@@ -730,12 +730,19 @@ GtPharoMethodCoder >> forMethod: aCompiledMethod in: aBehavior [
 
 { #category : #accessing }
 GtPharoMethodCoder >> formatWithRequesterObject: aRequester [
-	| ast |
-	ast := [ RBParser parseMethod: self currentSourceString ]
-			on: RBParser gtParseErrorClass
-			do: [ :ex | ^ self notifyParseError: ex requesterObject: aRequester ].
-
-	self currentSourceString: ast formattedCode
+	| ast originalSource formatted |
+	originalSource := self currentSourceString.
+	ast := [RBParser parseMethod: originalSource]
+				on: RBParser gtParseErrorClass
+				do: [:ex | ^self notifyParseError: ex requesterObject: aRequester].
+	formatted := ast formattedCode.
+	self currentSourceString: formatted.
+	self
+		updateSelectionAfterFormatOf: aRequester
+		from: ast
+		to: (RBParser parseMethod: formatted)
+		originalSource: originalSource
+		formattedSource: formatted
 ]
 
 { #category : #'gt-extensions' }

--- a/src/GToolkit-Pharo-Coder-Method/GtPharoSourceCoder.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtPharoSourceCoder.class.st
@@ -80,26 +80,39 @@ GtPharoSourceCoder >> compilerErrorsToHandle [
 
 { #category : #'private - actions' }
 GtPharoSourceCoder >> computePositionMappingsFrom: originalAst to: formattedAst [
-	| origScanner origTokens fmtScanner fmtTokens mappings |
-	origScanner := RBScanner on: originalAst source readStream.
+	| origTokens fmtTokens mappings scanner origIdx fmtIdx |
+	scanner := RBScanner on: originalAst source readStream.
 	origTokens := OrderedCollection new.
-	[origScanner atEnd] whileFalse: [origTokens add: origScanner next].
-	fmtScanner := RBScanner on: formattedAst source readStream.
+	[ scanner atEnd ] whileFalse: [ origTokens add: scanner next ].
+	scanner := RBScanner on: formattedAst source readStream.
 	fmtTokens := OrderedCollection new.
-	[fmtScanner atEnd] whileFalse: [fmtTokens add: fmtScanner next].
+	[ scanner atEnd ] whileFalse: [ fmtTokens add: scanner next ].
 	mappings := OrderedCollection new: origTokens size.
-	1 to: (origTokens size min: fmtTokens size)
-		do: 
-			[:i |
-			| orig fmt |
-			orig := origTokens at: i.
-			fmt := fmtTokens at: i.
-			mappings add: (GtSourceCoderFormatTokenMapping
-						originalStart: orig start
-						originalStop: orig stop
-						formattedStart: fmt start
-						formattedStop: fmt stop)].
-	^GtSourceCoderFormatPositionMap tokenMappings: mappings
+	origIdx := 1.
+	fmtIdx := 1.
+	[ origIdx <= origTokens size and: [ fmtIdx <= fmtTokens size ] ]
+		whileTrue: [ | orig fmt |
+			orig := origTokens at: origIdx.
+			fmt := fmtTokens at: fmtIdx.
+			orig value = fmt value
+				ifTrue: [ mappings
+						add: (GtSourceCoderFormatTokenMapping
+								originalStart: orig start
+								originalStop: orig stop
+								formattedStart: fmt start
+								formattedStop: fmt stop).
+					origIdx := origIdx + 1.
+					fmtIdx := fmtIdx + 1 ]
+				ifFalse: [ | origFoundInFmt |
+					origFoundInFmt := (fmtIdx + 1 to: fmtTokens size)
+							anySatisfy: [ :j | (fmtTokens at: j) value = orig value ].
+					origFoundInFmt
+						ifTrue: [ fmtIdx := fmtIdx + 1 ]
+						ifFalse: [ origIdx := origIdx + 1 ] ] ].
+	^ GtSourceCoderFormatPositionMap
+		tokenMappings: mappings
+		originalSource: originalAst source
+		formattedSource: formattedAst source
 ]
 
 { #category : #'private - ast' }
@@ -367,16 +380,15 @@ GtPharoSourceCoder >> targetAstParserClass [
 { #category : #'private - actions' }
 GtPharoSourceCoder >> updateSelectionAfterFormatOf: aRequester from: originalAst to: formattedAst originalSource: anOriginalString formattedSource: aFormattedString [
 	| positionMap event mapped |
-	positionMap := self computePositionMappingsFrom: originalAst
-				to: formattedAst.
+	positionMap := self computePositionMappingsFrom: originalAst to: formattedAst.
 	event := GtSourceCoderFormattedEvent
-				originalSource: anOriginalString
-				formattedSource: aFormattedString
-				positionMap: positionMap.
+			originalSource: anOriginalString
+			formattedSource: aFormattedString
+			positionMap: positionMap.
 	self announce: event.
-	(aRequester isNil or: [aRequester hasSelection not]) ifTrue: [^self].
+	(aRequester isNil or: [ aRequester hasSelection not ]) ifTrue: [ ^ self ].
 	mapped := positionMap
-				mapRange: (aRequester selection from + 1 to: aRequester selection to).
+			mapRange: (aRequester selection from + 1 to: aRequester selection to).
 	aRequester selectNone.
 	aRequester select: mapped first - 1 to: mapped last
 ]

--- a/src/GToolkit-Pharo-Coder-Method/GtPharoSourceCoder.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtPharoSourceCoder.class.st
@@ -78,6 +78,30 @@ GtPharoSourceCoder >> compilerErrorsToHandle [
 	^ OCUndeclaredVariableWarning, RBParser gtParseErrorClass
 ]
 
+{ #category : #'private - actions' }
+GtPharoSourceCoder >> computePositionMappingsFrom: originalAst to: formattedAst [
+	| origScanner origTokens fmtScanner fmtTokens mappings |
+	origScanner := RBScanner on: originalAst source readStream.
+	origTokens := OrderedCollection new.
+	[origScanner atEnd] whileFalse: [origTokens add: origScanner next].
+	fmtScanner := RBScanner on: formattedAst source readStream.
+	fmtTokens := OrderedCollection new.
+	[fmtScanner atEnd] whileFalse: [fmtTokens add: fmtScanner next].
+	mappings := OrderedCollection new: origTokens size.
+	1 to: (origTokens size min: fmtTokens size)
+		do: 
+			[:i |
+			| orig fmt |
+			orig := origTokens at: i.
+			fmt := fmtTokens at: i.
+			mappings add: (GtSourceCoderFormatTokenMapping
+						originalStart: orig start
+						originalStop: orig stop
+						formattedStart: fmt start
+						formattedStop: fmt stop)].
+	^GtSourceCoderFormatPositionMap tokenMappings: mappings
+]
+
 { #category : #'private - ast' }
 GtPharoSourceCoder >> detectReferencesFilterAt: aTextPosition ifFound: aFoundBlock ifNone: aNoneBlock [
 	^ self 
@@ -103,12 +127,19 @@ GtPharoSourceCoder >> format [
 
 { #category : #'api - actions' }
 GtPharoSourceCoder >> formatWithRequesterObject: aRequester [
-	| ast |
-	ast := [ RBParser parseExpression: self currentSourceString ]
-			on: RBParser gtParseErrorClass
-			do: [ :ex | ^ self notifyParseError: ex requesterObject: aRequester ].
-
-	self currentSourceString: ast formattedCode
+	| ast originalSource formatted |
+	originalSource := self currentSourceString.
+	ast := [RBParser parseExpression: originalSource]
+				on: RBParser gtParseErrorClass
+				do: [:ex | ^self notifyParseError: ex requesterObject: aRequester].
+	formatted := ast formattedCode.
+	self currentSourceString: formatted.
+	self
+		updateSelectionAfterFormatOf: aRequester
+		from: ast
+		to: (RBParser parseExpression: formatted)
+		originalSource: originalSource
+		formattedSource: formatted
 ]
 
 { #category : #'private - actions' }
@@ -331,4 +362,21 @@ GtPharoSourceCoder >> source [
 { #category : #accessing }
 GtPharoSourceCoder >> targetAstParserClass [
 	^ GtPharoParser
+]
+
+{ #category : #'private - actions' }
+GtPharoSourceCoder >> updateSelectionAfterFormatOf: aRequester from: originalAst to: formattedAst originalSource: anOriginalString formattedSource: aFormattedString [
+	| positionMap event mapped |
+	positionMap := self computePositionMappingsFrom: originalAst
+				to: formattedAst.
+	event := GtSourceCoderFormattedEvent
+				originalSource: anOriginalString
+				formattedSource: aFormattedString
+				positionMap: positionMap.
+	self announce: event.
+	(aRequester isNil or: [aRequester hasSelection not]) ifTrue: [^self].
+	mapped := positionMap
+				mapRange: (aRequester selection from + 1 to: aRequester selection to).
+	aRequester selectNone.
+	aRequester select: mapped first - 1 to: mapped last
 ]

--- a/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatPositionMap.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatPositionMap.class.st
@@ -2,27 +2,33 @@ Class {
 	#name : #GtSourceCoderFormatPositionMap,
 	#superclass : #Object,
 	#instVars : [
-		'tokenMappings'
+		'tokenMappings',
+		'originalSource',
+		'formattedSource'
 	],
 	#category : #'GToolkit-Pharo-Coder-Method'
 }
 
 { #category : #'instance creation' }
-GtSourceCoderFormatPositionMap class >> tokenMappings: aCollection [
-	^self new setTokenMappings: aCollection
+GtSourceCoderFormatPositionMap class >> tokenMappings: aCollection originalSource: anOriginalString formattedSource: aFormattedString [
+	^ self new
+		setTokenMappings: aCollection
+		originalSource: anOriginalString
+		formattedSource: aFormattedString
 ]
 
 { #category : #mapping }
 GtSourceCoderFormatPositionMap >> mapPosition: anOriginalPosition [
-	tokenMappings reverseDo: 
-			[:mapping |
+	tokenMappings
+		reverseDo: [ :mapping | 
 			(mapping includesOriginalPosition: anOriginalPosition)
-				ifTrue: [^mapping mapPosition: anOriginalPosition]].
-	tokenMappings reverseDo: 
-			[:mapping |
-			mapping originalStop < anOriginalPosition
-				ifTrue: [^anOriginalPosition + mapping offset]].
-	^anOriginalPosition
+				ifTrue: [ ^ mapping
+						mapPosition: anOriginalPosition
+						inOriginalSource: originalSource
+						formattedSource: formattedSource ] ].
+	tokenMappings
+		reverseDo: [ :mapping | mapping originalStop < anOriginalPosition ifTrue: [ ^ mapping formattedStop ] ].
+	^ anOriginalPosition
 ]
 
 { #category : #mapping }
@@ -34,8 +40,10 @@ GtSourceCoderFormatPositionMap >> mapRange: anInterval [
 ]
 
 { #category : #private }
-GtSourceCoderFormatPositionMap >> setTokenMappings: aCollection [
-	tokenMappings := aCollection
+GtSourceCoderFormatPositionMap >> setTokenMappings: aCollection originalSource: anOriginalString formattedSource: aFormattedString [
+	tokenMappings := aCollection.
+	originalSource := anOriginalString.
+	formattedSource := aFormattedString
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatPositionMap.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatPositionMap.class.st
@@ -1,0 +1,49 @@
+Class {
+	#name : #GtSourceCoderFormatPositionMap,
+	#superclass : #Object,
+	#instVars : [
+		'tokenMappings'
+	],
+	#category : #'GToolkit-Pharo-Coder-Method'
+}
+
+{ #category : #'instance creation' }
+GtSourceCoderFormatPositionMap class >> tokenMappings: aCollection [
+	^self new setTokenMappings: aCollection
+]
+
+{ #category : #mapping }
+GtSourceCoderFormatPositionMap >> mapPosition: anOriginalPosition [
+	tokenMappings reverseDo: 
+			[:mapping |
+			(mapping includesOriginalPosition: anOriginalPosition)
+				ifTrue: [^mapping mapPosition: anOriginalPosition]].
+	tokenMappings reverseDo: 
+			[:mapping |
+			mapping originalStop < anOriginalPosition
+				ifTrue: [^anOriginalPosition + mapping offset]].
+	^anOriginalPosition
+]
+
+{ #category : #mapping }
+GtSourceCoderFormatPositionMap >> mapRange: anInterval [
+	| mappedStart mappedEnd |
+	mappedStart := self mapPosition: anInterval first.
+	mappedEnd := self mapPosition: anInterval last.
+	^mappedStart to: mappedEnd
+]
+
+{ #category : #private }
+GtSourceCoderFormatPositionMap >> setTokenMappings: aCollection [
+	tokenMappings := aCollection
+]
+
+{ #category : #accessing }
+GtSourceCoderFormatPositionMap >> size [
+	^tokenMappings size
+]
+
+{ #category : #accessing }
+GtSourceCoderFormatPositionMap >> tokenMappings [
+	^tokenMappings
+]

--- a/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatTokenMapping.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatTokenMapping.class.st
@@ -39,6 +39,40 @@ GtSourceCoderFormatTokenMapping >> mapPosition: anOriginalPosition [
 	^formattedStart + (anOriginalPosition - originalStart)
 ]
 
+{ #category : #mapping }
+GtSourceCoderFormatTokenMapping >> mapPosition: anOriginalPosition inOriginalSource: anOriginalString formattedSource: aFormattedString [
+	| origSize fmtSize |
+	origSize := originalStop - originalStart + 1.
+	fmtSize := formattedStop - formattedStart + 1.
+	(origSize = fmtSize or: [ anOriginalString isNil ])
+		ifTrue: [ ^ self mapPosition: anOriginalPosition ].
+	^ self
+		mapPositionByCharacterMatch: anOriginalPosition
+		inOriginalSource: anOriginalString
+		formattedSource: aFormattedString
+]
+
+{ #category : #mapping }
+GtSourceCoderFormatTokenMapping >> mapPositionByCharacterMatch: anOriginalPosition inOriginalSource: anOriginalString formattedSource: aFormattedString [
+	| char occurrence fmtTokenStr idx searchFrom |
+	char := anOriginalString at: anOriginalPosition.
+	occurrence := 0.
+	originalStart
+		to: anOriginalPosition
+		do: [ :i | (anOriginalString at: i) = char ifTrue: [ occurrence := occurrence + 1 ] ].
+	fmtTokenStr := aFormattedString copyFrom: formattedStart to: formattedStop.
+	idx := 0.
+	searchFrom := 0.
+	1
+		to: occurrence
+		do: [ :o | 
+			idx := fmtTokenStr indexOf: char startingAt: searchFrom + 1.
+			idx > 0 ifTrue: [ searchFrom := idx ] ].
+	idx > 0
+		ifTrue: [ ^ formattedStart + idx - 1 ]
+		ifFalse: [ ^ self mapPosition: anOriginalPosition ]
+]
+
 { #category : #accessing }
 GtSourceCoderFormatTokenMapping >> offset [
 	^formattedStart - originalStart

--- a/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatTokenMapping.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormatTokenMapping.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : #GtSourceCoderFormatTokenMapping,
+	#superclass : #Object,
+	#instVars : [
+		'originalStart',
+		'originalStop',
+		'formattedStart',
+		'formattedStop'
+	],
+	#category : #'GToolkit-Pharo-Coder-Method'
+}
+
+{ #category : #'instance creation' }
+GtSourceCoderFormatTokenMapping class >> originalStart: aStart originalStop: aStop formattedStart: aFmtStart formattedStop: aFmtStop [
+	^self new
+		setOriginalStart: aStart
+		originalStop: aStop
+		formattedStart: aFmtStart
+		formattedStop: aFmtStop
+]
+
+{ #category : #accessing }
+GtSourceCoderFormatTokenMapping >> formattedStart [
+	^formattedStart
+]
+
+{ #category : #accessing }
+GtSourceCoderFormatTokenMapping >> formattedStop [
+	^formattedStop
+]
+
+{ #category : #testing }
+GtSourceCoderFormatTokenMapping >> includesOriginalPosition: aPosition [
+	^originalStart <= aPosition and: [originalStop >= aPosition]
+]
+
+{ #category : #mapping }
+GtSourceCoderFormatTokenMapping >> mapPosition: anOriginalPosition [
+	^formattedStart + (anOriginalPosition - originalStart)
+]
+
+{ #category : #accessing }
+GtSourceCoderFormatTokenMapping >> offset [
+	^formattedStart - originalStart
+]
+
+{ #category : #accessing }
+GtSourceCoderFormatTokenMapping >> originalStart [
+	^originalStart
+]
+
+{ #category : #accessing }
+GtSourceCoderFormatTokenMapping >> originalStop [
+	^originalStop
+]
+
+{ #category : #printing }
+GtSourceCoderFormatTokenMapping >> printOn: aStream [
+	aStream
+		nextPutAll: '[';
+		print: originalStart;
+		nextPut: $-;
+		print: originalStop;
+		nextPutAll: ' | ';
+		print: formattedStart;
+		nextPut: $-;
+		print: formattedStop;
+		nextPut: $]
+]
+
+{ #category : #private }
+GtSourceCoderFormatTokenMapping >> setOriginalStart: aStart originalStop: aStop formattedStart: aFmtStart formattedStop: aFmtStop [
+	originalStart := aStart.
+	originalStop := aStop.
+	formattedStart := aFmtStart.
+	formattedStop := aFmtStop
+]

--- a/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormattedEvent.class.st
+++ b/src/GToolkit-Pharo-Coder-Method/GtSourceCoderFormattedEvent.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : #GtSourceCoderFormattedEvent,
+	#superclass : #BlEvent,
+	#instVars : [
+		'originalSource',
+		'formattedSource',
+		'positionMap'
+	],
+	#category : #'GToolkit-Pharo-Coder-Method'
+}
+
+{ #category : #'instance creation' }
+GtSourceCoderFormattedEvent class >> originalSource: anOriginalString formattedSource: aFormattedString positionMap: aPositionMap [
+	^(self new)
+		originalSource: anOriginalString;
+		formattedSource: aFormattedString;
+		positionMap: aPositionMap
+]
+
+{ #category : #accessing }
+GtSourceCoderFormattedEvent >> charactersAdded [
+	^formattedSource size - originalSource size
+]
+
+{ #category : #accessing }
+GtSourceCoderFormattedEvent >> formattedSource [
+	^formattedSource
+]
+
+{ #category : #accessing }
+GtSourceCoderFormattedEvent >> formattedSource: aString [
+	formattedSource := aString
+]
+
+{ #category : #mapping }
+GtSourceCoderFormattedEvent >> mapPosition: anOriginalPosition [
+	^positionMap mapPosition: anOriginalPosition
+]
+
+{ #category : #accessing }
+GtSourceCoderFormattedEvent >> originalSource [
+	^originalSource
+]
+
+{ #category : #accessing }
+GtSourceCoderFormattedEvent >> originalSource: aString [
+	originalSource := aString
+]
+
+{ #category : #accessing }
+GtSourceCoderFormattedEvent >> positionMap [
+	^positionMap
+]
+
+{ #category : #accessing }
+GtSourceCoderFormattedEvent >> positionMap: aGtSourceCoderFormatPositionMap [
+	positionMap := aGtSourceCoderFormatPositionMap
+]


### PR DESCRIPTION
This PR fixes [#4822](https://github.com/feenkcom/gtoolkit/issues/4822).

After formatting (Shift+Ctrl+F) the selection now adapts to the new positions such that the same logical text remains selected. Additionally it introduces `GtSourceCoderFormattedEvent` fired on the coder announcer, carrying a full position map for external subscribers to react to formatting changes. Position mapping uses `RBScanner` to tokenize both original and formatted source, pairing every token by index.